### PR TITLE
Fix minor typo in Licensing topic

### DIFF
--- a/Writerside/topics/about/Licensing.topic
+++ b/Writerside/topics/about/Licensing.topic
@@ -178,14 +178,14 @@
             While the EUPL applies specifically to Kord Extensions above, we felt it was worth explaining the specifics
             of what it means for your projects.
         </p>
-        
+
         <chapter title="Linking" id="your-work-linking">
             <p>
                 While the legal definition for linking hasn't been tested in Europe, we understand it to mean
-                the copying of names and API definitions from another project yours is compiled against, without 
+                the copying of names and API definitions from another project yours is compiled against, without
                 actually distributing the project you're linking to.
             </p>
-            
+
             <p>
                 Under European law, this doesn't require rights-holder permission, and it doesn't impact how your
                 project must be distributed or licensed.

--- a/Writerside/topics/about/Licensing.topic
+++ b/Writerside/topics/about/Licensing.topic
@@ -208,7 +208,7 @@
 
                 Additionally,
                 <format style="bold">you are not allowed to remove the references to Kord Extensions</format> in
-                <a href="Config-About.topic">tne about command</a> (including removing the command or extension),
+                <a href="Config-About.topic">the about command</a> (including removing the command or extension),
                 unless you reproduce those references in another public command with equal visibility.
             </p>
 


### PR DESCRIPTION
This PR fixes a minor type in the Licensing topic/page, as reported by @SilverAndro in a Discord server (and my own initiative to make a PR, because why not).

This also removes some trailing whitespace, to make that part consistent in whitespace with the rest of the file.

However, please note that the EditorConfig says files should use tabs for indentation, but the Licensing topic/page uses spaces for indentation. For the sake of not confusing the typo fix and the whitespace changes, I've not corrected the indentation and will leave it up to maintainer's discretion.